### PR TITLE
Allow setting custom initial Redux state with createElmReducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const createElmMiddleware = (elm) => {
 
 export default createElmMiddleware
 
-export const reducer = function(state = {}, action) {
+export const createElmReducer = (init) => (state = init, action) => {
   const [elmAction, type] = action.type.split('/')
   if (elmAction === ELM) {
     return action.payload
@@ -36,3 +36,5 @@ export const reducer = function(state = {}, action) {
 
   return state
 }
+
+export const reducer = createElmReducer({})

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import testReducer from 'redux-test-reducer'
-import { reducer } from '../src'
+import { reducer, createElmReducer } from '../src'
 
 describe('Reducer', () => {
   it('should be a function', () => {
@@ -30,6 +30,24 @@ describe('Reducer', () => {
     const assertReducer = testReducer(reducer)
     const from = {
       init: true
+    }
+    const to = from
+    const action = {
+      type: 'OTHER_ACTION',
+      payload: {
+        foo: true
+      }
+    }
+    assertReducer({
+      from, to, action
+    })
+  })
+
+  it('allows setting the initial state with createElmReducer', () => {
+    const customInit = 1
+    const assertReducer = testReducer(createElmReducer(customInit))
+    const from = {
+      init: customInit
     }
     const to = from
     const action = {


### PR DESCRIPTION
Instead of importing `reducer`, you can now import the `createElmReducer` function, which takes an initial state and returns a reducer. Backwards compatibility is kept by exporting `reducer` as `createElmReducer({})`.

Sort of related to #103, in as far as it lets the user set the initial Redux state. Actually setting the state from `init` proved harder, since it doesn't seem possible to get the value of `init` from JS. One possible solution would be to allow a `programWithFlags` and set the `init` and intial Redux state from JS.